### PR TITLE
Remove activation events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 clarity.json
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
       },
     "icon": "images/blockstack-logo.png",
     "qna": "https://clarity-lang.org/",
-    "activationEvents": [
-        "onLanguage:clarity"
-    ],
     "contributes": {
         "languages": [
             {


### PR DESCRIPTION
Removed the `activationEvents` entry in the extension manifest (package.json) as it was preventing the extension from starting up, and I don't believe it was being used for anything.